### PR TITLE
Migrated to selecting non-seizure recordings by seizure count 

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -23,6 +23,9 @@ class DataConfig:
         )
     )
     patients_to_process: ClassVar[list[int]] = config["data"]["patients_to_process"]
+    file_undersampling_percent: ClassVar[int] = config["data"][
+        "file_undersampling_percent"
+    ]
 
 
 @dataclass

--- a/src/preprocessing/data_cleaning.py
+++ b/src/preprocessing/data_cleaning.py
@@ -90,7 +90,7 @@ def extract_seizure_intervals(
                 interval = EpochInterval(
                     phase="interictal",
                     start=0,
-                    end=min(3600, duration_seconds),
+                    end=duration_seconds,
                     file_name=file_name,
                 )
                 interictal_intervals.append(interval)

--- a/src/preprocessing/run_precompute_stfts_pipeline.py
+++ b/src/preprocessing/run_precompute_stfts_pipeline.py
@@ -90,6 +90,10 @@ def main():
                 f"with {len(filtered_interictal_intervals)} interictal intervals"
             )
 
+            logger.info(
+                f"Selected non-seizure files for interictal intervals: {cropped_no_seizure_filenames}"
+            )
+
             seizure_filenames = [file.file_name for file in seizure_files_data]
             no_seizure_filenames = [file.file_name for file in cropped_no_seizure_files]
             total_files = seizure_filenames + no_seizure_filenames

--- a/src/preprocessing/run_precompute_stfts_pipeline.py
+++ b/src/preprocessing/run_precompute_stfts_pipeline.py
@@ -63,15 +63,18 @@ def main():
                 ) = extract_seizure_intervals(patient_summary)
                 logger.info(f"Number of seizures: {len(ictal_intervals)}")
 
-            # TODO:
-            # [] limit no_seizure_intervals to just the total number of seizures
-            # [] read only filtered files
-
             combined_intervals = (
                 preictal_intervals + interictal_intervals + ictal_intervals
             )
 
-            cropped_no_seizure_files = no_seizure_files_data[: len(ictal_intervals)]
+            keep_fraction = DataConfig.file_undersampling_percent
+            num_to_keep = int(len(no_seizure_files_data) * keep_fraction)
+            cropped_no_seizure_files = no_seizure_files_data[:num_to_keep]
+            logger.info(
+                f"Keeping {len(cropped_no_seizure_files)} of {len(no_seizure_files_data)} "
+                f"non-seizure files ({keep_fraction * 100:.0f}% kept)"
+            )
+
             seizure_filenames = [file.file_name for file in seizure_files_data]
             no_seizure_filenames = [file.file_name for file in cropped_no_seizure_files]
             total_files = seizure_filenames + no_seizure_filenames

--- a/src/preprocessing/run_precompute_stfts_pipeline.py
+++ b/src/preprocessing/run_precompute_stfts_pipeline.py
@@ -7,6 +7,7 @@ STFTS from the EEG recordings.
 
 import gc
 import os
+import random
 from typing import cast
 
 from mne.io.base import BaseRaw, concatenate_raws
@@ -16,7 +17,12 @@ from tqdm.contrib.logging import logging_redirect_tqdm
 from src.config import DataConfig
 from src.logger import get_all_active_loggers, setup_logger
 from src.preprocessing.data_transformation import precompute_stfts
-from src.utils import export_to_csv, is_precomputed_data_exists, load_patient_summary
+from src.utils import (
+    export_to_csv,
+    is_precomputed_data_exists,
+    load_patient_summary,
+    set_seed,
+)
 
 from .data_cleaning import (
     apply_filters,
@@ -30,6 +36,7 @@ active_loggers = get_all_active_loggers()
 
 
 def main():
+    set_seed()
     logger.info("Starting precomputation of STFTs for all patients")
 
     precomputed_stfts_summary: list[dict[str, int]] = []
@@ -64,7 +71,7 @@ def main():
 
             # Filter interictal intervals to only include the files we want to keep
             num_to_keep = len(ictal_intervals)
-            cropped_no_seizure_files = no_seizure_files_data[:num_to_keep]
+            cropped_no_seizure_files = random.sample(no_seizure_files_data, num_to_keep)
             cropped_no_seizure_filenames = {
                 file.file_name for file in cropped_no_seizure_files
             }


### PR DESCRIPTION
- selection of seizure count is randomized
- the amount of selected non-seizure recordings is based on the total seizure count of the patient
- duration of non-seizure files is now full recording length, previously it was cropped at 1hr to save memory
- non-seizure recordings that contain interictal segments are now being filtered wherein the selected files will have only have the created intervals and not all the non-seizure recordings