### PR TITLE
Fixes loading order of eeg recordings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "kaggle>=1.7.4.5",
     "matplotlib>=3.10.6",
     "mne>=1.10.1",
+    "natsort>=8.4.0",
     "numpy>=2.3.3",
     "pandas>=2.3.3",
     "prettytable>=3.16.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1129,6 +1129,15 @@ wheels = [
 ]
 
 [[package]]
+name = "natsort"
+version = "8.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/a9/a0c57aee75f77794adaf35322f8b6404cbd0f89ad45c87197a937764b7d0/natsort-8.4.0.tar.gz", hash = "sha256:45312c4a0e5507593da193dedd04abb1469253b601ecaf63445ad80f0a1ea581", size = 76575, upload-time = "2023-06-20T04:17:19.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl", hash = "sha256:4732914fb471f56b5cce04d7bae6f164a592c7712e1c85f9ef585e197299521c", size = 38268, upload-time = "2023-06-20T04:17:17.522Z" },
+]
+
+[[package]]
 name = "nbclient"
 version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2252,6 +2261,7 @@ dependencies = [
     { name = "kaggle" },
     { name = "matplotlib" },
     { name = "mne" },
+    { name = "natsort" },
     { name = "numpy" },
     { name = "pandas" },
     { name = "prettytable" },
@@ -2274,6 +2284,7 @@ requires-dist = [
     { name = "kaggle", specifier = ">=1.7.4.5" },
     { name = "matplotlib", specifier = ">=3.10.6" },
     { name = "mne", specifier = ">=1.10.1" },
+    { name = "natsort", specifier = ">=8.4.0" },
     { name = "numpy", specifier = ">=2.3.3" },
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "prettytable", specifier = ">=3.16.0" },


### PR DESCRIPTION
# Initial Bug
The load order of the eeg recordings is not in chronological order meaning there are time jumps in the concatenated raw recording making it not 'continuous' anymore. This bug was caused specifically by adding both lists, seizure filenames and non-seizure filenames, since they are different lists, the seizure files name will be above the non-seizure filenames. Interchanging them will not fix it and sorting the is only way to guarantee load order.

# Fix Made
The utilization of the python package called natsort is used to naturally sort the files name of the recordings to ensure that wen concatenated, the time-series is maintained. 

# Before and After
| Without natsorted() | With natsorted() |
|---------------------|------------------|
| ![Screenshot 2025-10-11 at 04 33 49](https://github.com/user-attachments/assets/a51a598d-4797-465d-896c-eeca9a06f2f7) |  ![Screenshot 2025-10-11 at 05 03 42](https://github.com/user-attachments/assets/ab192d3f-d8e7-4486-a4ba-eb663347f41d)

# Some Notes
- This did not fix the reduction of interictal windows in some patients like patient 01
- Upon testing patient 1 with this fix, no change in the amount of total windows created has been observed implying that these does not affect the number of windows created
- This is still to be tested in other patients to observe if this improves the  poor results gotten the unsorted loading of eeg recordings