### PR TITLE
The big revamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ checkpoints/
 *.ipynb
 *.zip
 saved_models/
+.stignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "fastapi>=0.118.0",
+    "h5py>=3.15.1",
+    "higher-spectrum>=0.3.0",
     "jupyterlab>=4.4.9",
     "jupyterlab-vim>=4.1.4",
     "kaggle>=1.7.4.5",
@@ -20,6 +22,7 @@ dependencies = [
     "scipy>=1.16.2",
     "seaborn>=0.13.2",
     "tensorboard>=2.20.0",
+    "timm>=1.0.20",
     "toml>=0.10.2",
     "torch>=2.8.0",
     "torchvision>=0.23.0",

--- a/src/datatypes.py
+++ b/src/datatypes.py
@@ -9,33 +9,28 @@ import numpy as np
 
 
 @dataclass
-class EpochInterval:
+class IntervalMeta:
     phase: Literal["preictal", "interictal", "ictal"]
     start: int
     end: int
     duration: Optional[int] = None
     windows_created: Optional[int] = None
     file_name: Optional[str] = None
-
-
-@dataclass
-class CombinedIntervals:
-    preictal_intervals: list[EpochInterval]
-    interictal_intervals: list[EpochInterval]
-    ictal_intervals: list[EpochInterval]
+    seizure_id: Optional[int] = None
 
 
 @dataclass(kw_only=True)
-class StftStore(EpochInterval):
+class StftStore(IntervalMeta):
     stft_db: np.ndarray
     power: np.ndarray
     Zxx: np.ndarray
     freqs: np.ndarray
     times: np.ndarray
+    mag: np.ndarray
 
 
 @dataclass(kw_only=True)
-class BandTimeStore(EpochInterval):
+class BandTimeStore(IntervalMeta):
     band_time: np.ndarray  # shape: (n_bands, n_times)
     times: np.ndarray
 
@@ -49,7 +44,7 @@ class PrecomputedStftSummary:
 
 
 @dataclass
-class IntervalFileInfo:
+class RecordingFileInfo:
     file_name: str
-    interval: EpochInterval
+    recording: IntervalMeta
     duration: int

--- a/src/logger.py
+++ b/src/logger.py
@@ -31,7 +31,7 @@ def setup_logger(name: str) -> logging.Logger:
     stream_handler.setLevel(log_level)
 
     formatter = logging.Formatter(
-        fmt="%(asctime)s | %(name)s | %(funcName)s | [%(levelname)s] %(message)s",
+        fmt="%(asctime)s | %(funcName)s | [%(levelname)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
     stream_handler.setFormatter(formatter)

--- a/src/model/classification/concat_model.py
+++ b/src/model/classification/concat_model.py
@@ -38,7 +38,7 @@ class ConcatModel(nn.Module):
 
         fused_feat = torch.cat([tf_feat_flat, bis_feat_flat], dim=1)  # [B, 2560]
         fused_feat = (
-            fused_feat.unsqueeze(-1).unsqueeze(-1).expand(-1, -1, 7, 7)
+            fused_feat.unsqueeze(-1).unsqueeze(-1).repeat(-1, -1, 7, 7)
         )  # [B, 2560, 7, 7]
 
         logits = self.attention_pool(fused_feat)

--- a/src/model/classification/multi_seizure_model.py
+++ b/src/model/classification/multi_seizure_model.py
@@ -43,7 +43,7 @@ class MultimodalSeizureModel(nn.Module):
         fused_feat = self.fusion(tf_feat_flat, bis_feat_flat)  # [B, 1280]
 
         # Reshape back to [B, 1280, 7, 7] for attention pooling
-        fused_feat = fused_feat.unsqueeze(-1).unsqueeze(-1).expand(-1, -1, 7, 7)
+        fused_feat = fused_feat.unsqueeze(-1).unsqueeze(-1).repeat(1, 1, 7, 7)
 
         # Classification
         logits = self.attention_pool(fused_feat)

--- a/src/model/data.py
+++ b/src/model/data.py
@@ -1,157 +1,199 @@
 import os
+from pathlib import Path
 
 import numpy as np
 import torch
-from torch import Tensor
-from torch.utils.data import DataLoader, TensorDataset
+from torch.utils.data import DataLoader, Dataset, TensorDataset
 
-from src.config import DataConfig, DataLoaderConfig
+from src.config import DataLoaderConfig
 from src.logger import setup_logger
+from src.preprocessing.data_transformation import normalize_to_imagenet
 
 logger = setup_logger(name="data")
 
 
-def get_filename_suffix(filename) -> str:
-    return "_".join(filename.replace(".npz", "").split("_")[-2:])
-
-
-def get_paired_dataset(patient_id: str) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+def epoch_key(filename: str) -> str:
     """
-    Loads paired (tf_tensor, bispec_tensor, label) for a specific patient.
-
-    Args:
-        patient_id: e.g., "patient_01"
-
-    Returns:
-        X_tf: array of time-frequency tensors
-        X_bis: array of bispectrum tensors
-        y: array of labels (0 = interictal, 1 = preictal)
+    Creates a unique key for matching TF and BIS files.
+    Keeps everything except the trailing suffix like '_tf' or '_bis'.
+    Example:
+        'preictal_chb02_16+_002282_002312_tf.npz' → 'preictal_chb02_16+_002282_002312'
+        'interictal_chb02_02_003075_003105_tf.npz' → 'interictal_chb02_02_003075_003105'
     """
+    stem = Path(filename).stem  # drops .npz
+    parts = stem.split("_")
 
-    patient_path = f"patient_{patient_id}"
-    tf_dir = os.path.join(
-        DataConfig.precomputed_data_path, patient_path, "time-frequency"
-    )
-    bis_dir = os.path.join(DataConfig.precomputed_data_path, patient_path, "bispectrum")
+    if parts[-1].isalpha():
+        parts = parts[:-1]
 
-    tf_files = [f for f in os.listdir(tf_dir) if f.endswith(".npz")]
-    bispec_files = [f for f in os.listdir(bis_dir) if f.endswith(".npz")]
+    return "_".join(parts)
 
-    tf_map = {get_filename_suffix(f): os.path.join(tf_dir, f) for f in tf_files}
-    bis_map = {get_filename_suffix(f): os.path.join(bis_dir, f) for f in bispec_files}
 
-    common_keys = sorted(set(tf_map.keys()) & set(bis_map.keys()))
+class PairedEEGDataset(Dataset):
+    def __init__(self, patient_id: str, root_dir: str):
+        patient_path = f"patient_{patient_id}"
+        tf_dir = os.path.join(root_dir, patient_path, "time-frequency")
+        bis_dir = os.path.join(root_dir, patient_path, "bispectrum")
 
-    tf_features, bis_features, labels = [], [], []
+        tf_files = [f for f in os.listdir(tf_dir) if f.endswith(".npz")]
+        bispec_files = [f for f in os.listdir(bis_dir) if f.endswith(".npz")]
 
-    for key in common_keys:
-        tf_path = tf_map[key]
-        bis_path = bis_map[key]
+        tf_map = {epoch_key(f): os.path.join(tf_dir, f) for f in tf_files}
+        bis_map = {epoch_key(f): os.path.join(bis_dir, f) for f in bispec_files}
 
-        tf_tensor = np.load(tf_path)["tensor"]
-        bis_tensor = np.load(bis_path)["tensor"]
+        common_keys = sorted(set(tf_map.keys()) & set(bis_map.keys()))
 
-        label = 1 if "preictal" in os.path.basename(tf_path) else 0
-        # Log for Verification (SORRY IF MADAMI LMAO)
-        logger.info(
-            f"Labelled {label} for {os.path.basename(tf_path)} and {os.path.basename(bis_path)}"
+        tf_list: list[np.ndarray] = []
+        bis_list: list[np.ndarray] = []
+        labels_list: list[int] = []
+        seizure_id_list: list[int] = []
+
+        interictal_file_names: list[str] = []
+
+        for key in common_keys:
+            tf_path = tf_map[key]
+            bis_path = bis_map[key]
+
+            # TODO: Change 'tensor' to 'image'
+            tf_npz = np.load(tf_path)
+            bis_npz = np.load(bis_path)
+
+            tf_image = np.array(tf_npz["tensor"], dtype=np.float32)
+            bis_image = np.array(bis_npz["tensor"], dtype=np.float32)
+
+            # Normalize to imagenet specs
+            tf_image = normalize_to_imagenet(tf_image)
+
+            bis_image = bis_image.astype(np.float32)
+            bis_image = (bis_image - bis_image.mean()) / (bis_image.std() + 1e-8)
+
+            seizure_id = int(np.load(tf_path)["seizure_id"])
+
+            label = 1 if "preictal" in os.path.basename(tf_path) else 0
+            logger.info(
+                f"Labelled {label} for {os.path.basename(tf_path)} and {os.path.basename(bis_path)} | seizure id: {seizure_id}"
+            )
+
+            tf_list.append(tf_image)
+            bis_list.append(bis_image)
+            labels_list.append(label)
+            seizure_id_list.append(seizure_id)
+
+        # Convert features, labels, and ids into tensors
+        self.tf_features: torch.Tensor = torch.tensor(
+            np.stack(tf_list), dtype=torch.float32
         )
-        tf_features.append(tf_tensor)
-        bis_features.append(bis_tensor)
-        labels.append(label)
+        self.bis_features: torch.Tensor = torch.tensor(
+            np.stack(bis_list), dtype=torch.float32
+        )
+        self.labels: torch.Tensor = torch.tensor(labels_list, dtype=torch.long)
+        self.seizure_ids: torch.Tensor = torch.tensor(seizure_id_list, dtype=torch.long)
 
-    return np.array(tf_features), np.array(bis_features), np.array(labels)
+    def __len__(self):
+        return len(self.tf_features)
+
+    def __getitem__(
+        self, idx: int
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        tf_tensor: torch.Tensor = self.tf_features[idx]
+        bis_tensor: torch.Tensor = self.bis_features[idx]
+        label: torch.Tensor = self.labels[idx]
+        seizure_id: torch.Tensor = self.seizure_ids[idx]
+
+        return tf_tensor, bis_tensor, label, seizure_id
 
 
 def get_loocv_fold(
-    tf_tensor: Tensor,
-    bis_tensor: Tensor,
-    labels_tensor: Tensor,
-    sample_idx: int,
-    undersample: bool,
-) -> tuple[tuple[Tensor, Tensor, Tensor], tuple[Tensor, Tensor, Tensor]]:
-    """
-    Creates split train and test data through leave-one-out cross-validation (LOOCV)
+    dataset: PairedEEGDataset,
+    n_chunks: int,
+    n_folds: int,
+    fold_idx: int,
+    undersample: bool = True,
+) -> tuple[
+    tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+    tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+]:
+    # TODO: go back to the old N parts split
+    # https://excalidraw.com
 
-    Args:
-        tf_features (np.ndarray): Numpy array of time-frequency features
-        bis_features (np.ndarray): Numpy array of bispectrum features
-        labels (np.ndarray): Numpy array of feature labels (0 = interictal, 1 = preictal)
-        undersample: if True, applies random undersampling
+    logger.info(f"Leaving out fold {fold_idx}")
 
-    Returns:
-        tuple[tuple[Tensor, Tensor, Tensor], tuple[Tensor, Tensor, Tensor]]:
-            The train and test tensors
-    """
+    tf_features = dataset.tf_features
+    bis_features = dataset.bis_features
+    labels = dataset.labels
+
+    # Split features and labels into N
+    # The splitting works by splitting the entire tensor into chunks.
+    # Each tensor would have equal chunks based on n_splits
+    #
+    # Another thing to keep in mind is that N seizures is the
+    # amount of samples we have per fold so N is 5 then each fold would have around 5
+    # samples each but some may have more less depends if its its divisible, but torch.split
+    # wil handle those cases.
+
+    preictal_mask = labels == 1
+    interictal_mask = labels == 0
+
+    preictal_idx = torch.where(preictal_mask)[0]
+    interictal_idx = torch.where(interictal_mask)[0]
 
     logger.info(
-        f"Fold {sample_idx + 1} / {len(tf_tensor)} (leaving out sample {sample_idx})"
+        f"Preictal indices count: {len(preictal_idx)}, interictal indices count: {len(interictal_idx)}"
     )
 
-    mask = torch.arange(len(labels_tensor)) != sample_idx
+    preictal_splits = torch.split(preictal_idx, n_chunks)
+    interictal_splits = torch.split(interictal_idx, n_chunks)
 
-    tf_train = tf_tensor[mask]
-    bis_train = bis_tensor[mask]
-    labels_train = labels_tensor[mask]
+    assert len(preictal_splits) == len(interictal_splits), "Classes must split evenly"
+    assert 0 <= fold_idx < n_folds, "fold_idx exceeds available folds"
 
-    tf_test = tf_tensor[~mask]
-    bis_test = bis_tensor[~mask]
-    labels_test = labels_tensor[~mask]
+    logger.info(f"Preictal splits size: {len(preictal_splits)}")
+    logger.info(f"Interictal splits size: {len(interictal_splits)}")
 
-    if undersample:
-        unique, counts = torch.unique(labels_train, return_counts=True)
-        class_counts = dict(zip(unique.tolist(), counts.tolist()))
-        logger.info(f"Original training set class distribution: {class_counts}")
+    preictal_train = torch.cat(
+        [preictal_splits[index] for index in range(n_folds) if index != fold_idx]
+    )
+    interictal_train = torch.cat(
+        [interictal_splits[index] for index in range(n_folds) if index != fold_idx]
+    )
 
-        minority = torch.argmin(counts)
-        minority_class = unique[minority].item()
-        minority_count = counts[minority].item()
-        logger.info(f"Minority class: {minority_class} (count: {minority_count})")
+    # We then combine back both preictals and interictals into a single tensor
+    train_mask = torch.cat([preictal_train, interictal_train])
+    test_mask = torch.cat([preictal_splits[fold_idx], interictal_splits[fold_idx]])
 
-        indices_min = torch.where(labels_train == minority_class)[0]
-        indices_maj = torch.where(labels_train != minority_class)[0]
-        logger.info(
-            f"Majority class indices: {len(indices_maj)}, Minority class indices: {len(indices_min)}"
-        )
+    # After combining the preictals and interictals, we get the time-frequency features,
+    # bispectrum features, and the labels
+    tf_train = tf_features[train_mask]
+    bis_train = bis_features[train_mask]
+    labels_train = labels[train_mask]
 
-        sampled_maj = indices_maj[torch.randperm(len(indices_maj))[:minority_count]]
-
-        idx = torch.cat((indices_min, sampled_maj))
-        tf_train, bis_train, labels_train = (
-            tf_train[idx],
-            bis_train[idx],
-            labels_train[idx],
-        )
-
-        unique_new, counts_new = torch.unique(labels_train, return_counts=True)
-        new_class_counts = dict(zip(unique_new.tolist(), counts_new.tolist()))
-        logger.info(f"Undersampled training set class distribution: {new_class_counts}")
+    tf_test = tf_features[test_mask]
+    bis_test = bis_features[test_mask]
+    labels_test = labels[test_mask]
 
     return (tf_train, bis_train, labels_train), (tf_test, bis_test, labels_test)
 
 
-def create_data_loader(tensor_dataset: TensorDataset) -> DataLoader:
-    """
-    Creates a data loader for a dataset or tensor
-
-    Args:
-        dataset (Union[Dataset, Sequence[Tensor]]): Input to be used, can be either torch dataset
-        or tensor
-
-    Returns:
-        DataLoader: The created dataloader
-    """
-
-    dataset_size = len(tensor_dataset)
-    batch_size = 32 if dataset_size < 1000 else 256
-
-    logger.info(f"TensorDataset size: {dataset_size}, using batch size: {batch_size}")
-
-    return DataLoader(
-        dataset=tensor_dataset,
+def get_data_loaders(
+    train_set: TensorDataset,
+    test_set: TensorDataset,
+    batch_size: int = 32,
+    pin_memory: bool = True,
+) -> tuple[DataLoader, DataLoader]:
+    train_loader = DataLoader(
+        train_set,
         batch_size=batch_size,
-        shuffle=DataLoaderConfig.shuffle,
+        shuffle=True,
         num_workers=DataLoaderConfig.num_workers,
-        pin_memory=True,
-        persistent_workers=True,
+        pin_memory=pin_memory,
     )
+
+    test_loader = DataLoader(
+        test_set,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=DataLoaderConfig.num_workers,
+        pin_memory=pin_memory,
+    )
+
+    return train_loader, test_loader

--- a/src/model/metrics_utils.py
+++ b/src/model/metrics_utils.py
@@ -4,7 +4,9 @@ from dataclasses import asdict, dataclass
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
+import torch
 from prettytable import PrettyTable
+from torch import Tensor
 
 from src.config import DataConfig, Trainconfig
 from src.logger import setup_logger
@@ -198,3 +200,20 @@ def export_training_results(
         mode="a",
     )
     logger.info(f"Saved training results CSV to {training_results_path}")
+
+
+def compute_train_accuracy(outputs: Tensor, labels: Tensor) -> float:
+    """
+    Compute the number of correct predictions and total samples in a batch.
+
+    Args:
+        outputs (torch.Tensor): Model output logits of shape [B, num_classes].
+        labels (torch.Tensor): Ground-truth labels of shape [B].
+
+    Returns:
+        (correct, total): Tuple with number of correct predictions and total count.
+    """
+    preds = torch.argmax(outputs, dim=1)
+    correct = (preds == labels).sum().item()
+    total = labels.size(0)
+    return correct / total if total > 0 else 0.0

--- a/src/preprocessing/bispectrum_branch.py
+++ b/src/preprocessing/bispectrum_branch.py
@@ -106,9 +106,6 @@ def compute_bispectrum_estimation(
         coeffs, centers = Zxx, freqs
 
     n_bins = coeffs.shape[0]
-    logger.info(
-        f"Computing {'band-level' if PreprocessingConfig.band_level_bispectrum else 'full'} bispectrum for {n_bins} bins."
-    )
 
     B_complex = np.zeros((n_bins, n_bins), dtype=np.complex128)
     if freqs.size == 0 or Zxx.size == 0:
@@ -125,7 +122,6 @@ def compute_bispectrum_estimation(
         np.abs(freqs[left] - targets) <= np.abs(freqs[right] - targets), left, right
     )
     sum_idx = np.where(targets <= freqs[-1], nearest, -1).astype(int)
-    logger.debug("Computed nearest frequency indices for all band pairs.")
 
     conj_Zxx = np.conjugate(Zxx)
 
@@ -137,11 +133,6 @@ def compute_bispectrum_estimation(
             logger.debug(f"B[{i},{j}] skipped (target frequency out of range).")
             return 0j
         value = np.mean(Xi * coeffs[j] * conj_Zxx[idx])
-        logger.debug(
-            f"B[{i},{j}] computed using freq idx {idx} "
-            f"(center={centers[i] + centers[j]:.2f} Hz, "
-            f"{'band-level' if PreprocessingConfig.band_level_bispectrum else 'full'})."
-        )
         return complex(value)
 
     bispec_tasks: list[tuple[int, int, np.ndarray]] = [

--- a/src/preprocessing/data_cleaning.py
+++ b/src/preprocessing/data_cleaning.py
@@ -7,10 +7,12 @@ passing them to time-frequency and bispectrum processing.
 """
 
 import os
+import random
 import re
 import sys
 import typing
 from datetime import timedelta
+from typing import cast
 
 import mne
 from mne.io import BaseRaw
@@ -19,7 +21,7 @@ from tqdm import tqdm
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/../")
 
 from src.config import DataConfig, PreprocessingConfig
-from src.datatypes import EpochInterval, IntervalFileInfo
+from src.datatypes import IntervalMeta, RecordingFileInfo
 from src.logger import setup_logger
 from src.utils import parse_time_str
 
@@ -32,53 +34,32 @@ preictal_windows_count: int = 0
 interictal_windows_count: int = 0
 
 
-def extract_seizure_intervals(
-    patient_summary: typing.TextIO,
-) -> tuple[
-    list[EpochInterval],
-    list[EpochInterval],
-    list[EpochInterval],
-    list[IntervalFileInfo],
-    list[IntervalFileInfo],
-]:
+def parse_patient_summary_intervals(patient_summary: typing.TextIO):
     """
-    Extracts seizure intervals from a patient summart text file.
-
-    Necessary conversions since there are two time formats (seconds and datetime).
-
-    Args:
-        patient_summary (TextIO): Patient summary.txt file.
-
-    Returns:
-        tuple[list[SeizureInterval], list[SeizureInterval], list[SeizureInterval]
-            list[IntervalFileInfo], list[IntervalFileInfo], int]:
-            - preictal_intervals: Intervals before seizures.
-            - interictal_intervals: Intervals between seizures.
-            - ictal_intervals: Actual seizure intervals.
-            - seizure_files_data: Files (recordings) with seizures.
-            - no_seizure_files_data: Files
-
+    Parses a patient's summary file and extract all interval information.
+    Interval in the context of seizure is the seizure timeline and interval.
+    On the other hand, interval in the context of interictals are the full timeline
+    of non-seizure files limited to 1hr.
     """
 
-    preictal_intervals: list[EpochInterval] = []
-    interictal_intervals: list[EpochInterval] = []
-    ictal_intervals: list[EpochInterval] = []
+    preictal_intervals: list[IntervalMeta] = []
+    interictal_intervals: list[IntervalMeta] = []
+    ictal_intervals: list[IntervalMeta] = []
 
-    seizure_files_data: list[IntervalFileInfo] = []
-    no_seizure_files_data: list[IntervalFileInfo] = []
+    seizure_files_data: list[RecordingFileInfo] = []
+    no_seizure_files_data: list[RecordingFileInfo] = []
 
     file_name = ""
     pending_seizure_start = None
     file_start = None
     file_end = None
+    seizure_counter = 0
+    interictal_counter = 0
+    last_ictal_end_by_file: dict[str, int] = {}
+
+    logger.info("Only taking preictals that are more than 15mins in duration")
 
     for line in patient_summary:
-        # In order to get the preictal and interictal intervals, we need to loop through the
-        # patient summary file that contains the file start time, file end time, seizure start time,
-        # and seizure end time that would determine the file start, file end, and the
-        # seizures themselves. Then a seizure array will be used to store when the seizures started
-        # which will be used to find the preictals and interictals.
-
         line = line.strip()
 
         if line.startswith("File Name:"):
@@ -91,16 +72,18 @@ def extract_seizure_intervals(
             no_of_seizures = int(line.split(":", 1)[1].strip().split()[0])
             if no_of_seizures == 0 and file_start and file_end:
                 duration_seconds = int((file_end - file_start).total_seconds())
-                interval = EpochInterval(
+                recording = IntervalMeta(
                     phase="interictal",
                     start=0,
                     end=duration_seconds,
                     file_name=file_name,
+                    seizure_id=interictal_counter,
                 )
-                interictal_intervals.append(interval)
+                interictal_intervals.append(recording)
                 no_seizure_files_data.append(
-                    IntervalFileInfo(file_name, interval, duration_seconds)
+                    RecordingFileInfo(file_name, recording, duration_seconds)
                 )
+                interictal_counter += 1
         elif re.match(r"Seizure(\s+\d+)?\s+Start Time:", line):
             pending_seizure_start = int(line.split(":")[-1].strip().split()[0])
         elif (
@@ -112,77 +95,54 @@ def extract_seizure_intervals(
             if file_start and file_end:
                 duration_seconds = int((file_end - file_start).total_seconds())
 
-            ictal_interval = EpochInterval(
+            ictal_recording = IntervalMeta(
                 phase="ictal",
                 start=pending_seizure_start,
                 end=end_sec,
                 file_name=file_name,
+                seizure_id=seizure_counter,
             )
             seizure_files_data.append(
-                IntervalFileInfo(file_name, ictal_interval, duration_seconds)
+                RecordingFileInfo(file_name, ictal_recording, duration_seconds)
             )
-            ictal_intervals.append(ictal_interval)
-            pending_seizure_start = None
+            ictal_intervals.append(ictal_recording)
 
-    assert file_start is not None, "file_start cannot be None"
-    assert file_end is not None, "file_end cannot be None"
+            # Preictal intervals
+            preictal_minutes = PreprocessingConfig.preictal_minutes
+            seizure_start_sec = pending_seizure_start
 
-    current_start = file_start
-    for seizure_idx, seizure in enumerate(ictal_intervals, 1):
-        # Since the file start and times are in datatime format, in order to get the
-        # absolute datetimes of the seizure start/end from seconds, conversion has by using
-        # timedelta and adding it to the file_start datetime.
+            preictal_start_sec = max(0, seizure_start_sec - preictal_minutes * 60)
 
-        seizure_start_time = file_start + timedelta(seconds=seizure.start)
-        seizure_end_time = file_start + timedelta(seconds=seizure.end)
-        preictal_start_time = seizure_start_time - timedelta(
-            minutes=PreprocessingConfig.preictal_minutes
-        )
+            prev_end = last_ictal_end_by_file.get(file_name, 0)
+            preictal_start_sec = max(preictal_start_sec, prev_end)
 
-        logger.debug(
-            "seizure_start: %s, seizure_end: %s",
-            seizure.start,
-            seizure.end,
-        )
+            if file_start:
+                preictal_start_dt = file_start + timedelta(seconds=preictal_start_sec)
+                seizure_start_dt = file_start + timedelta(seconds=seizure_start_sec)
+                duration_min = (
+                    seizure_start_dt - preictal_start_dt
+                ).total_seconds() / 60.0
 
-        # We need to make sure that our times will never be negative
-        if preictal_start_time < current_start:
-            preictal_start_time = current_start
-        if preictal_start_time >= seizure_start_time:
-            preictal_start_time = file_start
-
-        # Interictal before preictal
-        if preictal_start_time > current_start:
-            interictal_intervals.append(
-                EpochInterval(
-                    phase="interictal",
-                    start=int((current_start - file_start).total_seconds()),
-                    end=int((preictal_start_time - file_start).total_seconds()),
-                    file_name=file_name,
+                logger.info(
+                    f"[{file_name}] Preictal {seizure_counter}: "
+                    f"start={preictal_start_dt.time()} end={seizure_start_dt.time()} "
+                    f"duration={duration_min:.1f} min"
                 )
-            )
 
-        preictal_intervals.append(
-            EpochInterval(
-                phase="preictal",
-                start=int((preictal_start_time - file_start).total_seconds()),
-                end=int((seizure_start_time - file_start).total_seconds()),
-                file_name=file_name,
-            )
-        )
+            if (seizure_start_sec - preictal_start_sec) >= 900:
+                preictal_intervals.append(
+                    IntervalMeta(
+                        phase="preictal",
+                        start=preictal_start_sec,
+                        end=seizure_start_sec,
+                        file_name=file_name,
+                        seizure_id=seizure_counter,
+                    )
+                )
 
-        current_start = seizure_end_time
-
-    # Interictal after last seizure
-    if file_end is not None and current_start < file_end:
-        interictal_intervals.append(
-            EpochInterval(
-                phase="interictal",
-                start=int((current_start - file_start).total_seconds()),
-                end=int((file_end - file_start).total_seconds()),
-                file_name=file_name,
-            )
-        )
+            last_ictal_end_by_file[file_name] = end_sec
+            pending_seizure_start = None
+            seizure_counter += 1
 
     return (
         preictal_intervals,
@@ -200,8 +160,6 @@ def load_raw_recordings(patient_id: str, file_names: list[str]) -> list[BaseRaw]
 
     Args:
         patient_id (str): Zero-padded patient ID (e.g. "01").
-        combined_intervals (list[EpochInterval]): List of the preictal, ictal,
-            and interictal intervals combined
 
     Returns:
         list[BaseRaw]: List of unprocessed raw recordings.
@@ -216,7 +174,7 @@ def load_raw_recordings(patient_id: str, file_names: list[str]) -> list[BaseRaw]
         file_names, desc=f"Reading EDF files for patient {patient_id}"
     ):
         recording_path = os.path.join(patient_folder, file_name)
-        logger.debug(f"Reading file: {file_name}")
+        logger.info(f"Reading file: {file_name}")
 
         raw_edf = mne.io.read_raw_edf(recording_path, preload=False, verbose="error")
         raw_channels = set(raw_edf.ch_names)
@@ -268,11 +226,46 @@ def apply_filters(
     return raw
 
 
+def balance_epochs(epochs: list[IntervalMeta]):
+    logger.info("Balancing epochs (matching total interictal to total preictal)...")
+
+    # Separate by phase
+    preictal = [ep for ep in epochs if ep.phase.lower() == "preictal"]
+    interictal = [ep for ep in epochs if ep.phase.lower() == "interictal"]
+
+    n_pre = len(preictal)
+    n_inter = len(interictal)
+
+    logger.info(f"Before balancing: preictal={n_pre}, interictal={n_inter}")
+
+    # If we have more interictals, randomly downsample them
+    if n_inter > n_pre:
+        interictal = random.sample(interictal, n_pre)
+        logger.info(f"Downsampled interictal from {n_inter} → {len(interictal)}")
+
+    # If we have fewer interictals, oversample (with replacement)
+    elif n_inter < n_pre and n_inter > 0:
+        extra = random.choices(interictal, k=n_pre - n_inter)
+        interictal += extra
+        logger.info(f"Oversampled interictal from {n_inter} → {len(interictal)}")
+
+    # Combine balanced sets
+    balanced = preictal + interictal
+
+    logger.info(
+        f"After balancing: preictal={len(preictal)}, interictal={len(interictal)}"
+    )
+    logger.info(f"Total balanced epochs: {len(balanced)}")
+
+    return balanced
+
+
 # 3. Preprocessing: Segmentation into epochs
-def segment_intervals(
-    intervals: list[EpochInterval],
+def segment_recordings(
+    recordings: list[IntervalMeta],
+    undersampling: bool,
     overlap: float = 0.5,  # 50% overlap
-) -> list[EpochInterval]:
+) -> list[IntervalMeta]:
     """
     Segments a seizure interval into overlapping, labeled epochs.
 
@@ -285,36 +278,60 @@ def segment_intervals(
         List[EpochInterval]: List of EpochInterval instances.
     """
 
-    logger.info("Segmenting intervals into 30-second epochs")
+    logger.info("Segmenting recordings into 30-second epochs")
     epoch_length = PreprocessingConfig.epoch_length
 
-    windows: list[EpochInterval] = []
+    epochs: list[IntervalMeta] = []
     step = max(1, int(epoch_length * (1 - overlap)))
 
-    for idx in tqdm(range(len(intervals))):
-        interval = intervals[idx]
+    # Match number of interictals with the number preictals recordings
+    preictal_intervals = [
+        recording for recording in recordings if recording.phase == "preictal"
+    ]
+    interictal_intervals = [
+        recording for recording in recordings if recording.phase == "interictal"
+    ]
+
+    sampled_interictals = random.sample(interictal_intervals, len(preictal_intervals))
+
+    # Reinintialize precital and interictal seizure ids to start at 0 again
+    for new_id, preictal in enumerate(preictal_intervals):
+        preictal.seizure_id = new_id
+
+    for new_id, interictal in enumerate(sampled_interictals):
+        interictal.seizure_id = new_id
+
+    balanced_recordings = preictal_intervals + sampled_interictals
+
+    for idx in tqdm(range(len(balanced_recordings))):
+        interval = cast(IntervalMeta, balanced_recordings[idx])
         start_sec, end_sec = int(interval.start), int(interval.end)
 
         current_start = start_sec
-        interval_windows = 0
+        interval_epochs = 0
 
         while current_start + epoch_length <= end_sec:
-            window_end = min(current_start + epoch_length, end_sec)
+            epoch = min(current_start + epoch_length, end_sec)
 
-            windows.append(
-                EpochInterval(
+            epochs.append(
+                IntervalMeta(
                     start=current_start,
-                    end=window_end,
+                    end=epoch,
                     phase=interval.phase,
+                    seizure_id=interval.seizure_id,
+                    file_name=interval.file_name,
                 )
             )
-            interval_windows += 1
+            interval_epochs += 1
             current_start += step
 
         logger.info(
-            f"Interval {idx + 1} ({interval.phase}): created {interval_windows} windows"
+            f"Interval {idx + 1} [{interval.file_name}] ({interval.phase}): created {interval_epochs} epochs"
         )
 
-    logger.info(f"Total windows created: {len(windows)}")
+    logger.info(f"Total epochs created: {len(epochs)}")
 
-    return windows
+    if undersampling:
+        epochs = balance_epochs(epochs)
+
+    return epochs

--- a/src/preprocessing/data_cleaning.py
+++ b/src/preprocessing/data_cleaning.py
@@ -262,7 +262,7 @@ def balance_epochs(epochs: list[IntervalMeta]):
 
 # 3. Preprocessing: Segmentation into epochs
 def segment_recordings(
-    recordings: list[IntervalMeta],
+    intervals: list[IntervalMeta],
     undersampling: bool,
     overlap: float = 0.5,  # 50% overlap
 ) -> list[IntervalMeta]:
@@ -286,13 +286,15 @@ def segment_recordings(
 
     # Match number of interictals with the number preictals recordings
     preictal_intervals = [
-        recording for recording in recordings if recording.phase == "preictal"
+        interval for interval in intervals if interval.phase == "preictal"
     ]
     interictal_intervals = [
-        recording for recording in recordings if recording.phase == "interictal"
+        interval for interval in intervals if interval.phase == "interictal"
     ]
 
-    sampled_interictals = random.sample(interictal_intervals, len(preictal_intervals))
+    sampled_interictals = random.sample(
+        interictal_intervals, min(len(interictal_intervals), len(preictal_intervals))
+    )
 
     # Reinintialize precital and interictal seizure ids to start at 0 again
     for new_id, preictal in enumerate(preictal_intervals):

--- a/src/preprocessing/data_transformation.py
+++ b/src/preprocessing/data_transformation.py
@@ -7,20 +7,19 @@ are the backbone for creating the precomputed STFTS as a whole.
 """
 
 import os
-import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import List, Literal, Optional, Tuple
+from threading import Lock
+from typing import Tuple
 
+import h5py
 import numpy as np
 from mne.io.base import BaseRaw
 from PIL import Image
 from scipy.signal import stft
-from sklearn.decomposition import PCA, FastICA
-from sklearn.preprocessing import minmax_scale
 from tqdm import tqdm
 
 from src.config import PreprocessingConfig
-from src.datatypes import BandTimeStore, EpochInterval, StftStore
+from src.datatypes import IntervalMeta, StftStore
 from src.logger import setup_logger
 
 logger = setup_logger(name="data_transformation")
@@ -86,117 +85,38 @@ def normalize_power_matrix(power_matrix: np.ndarray) -> np.ndarray:
         raise ValueError(f"Unknown normalization method: {normalization_method}")
 
 
-def normalize_to_unint8_rgb(arr: np.ndarray) -> np.ndarray:
+def normalize_array(
+    arr: np.ndarray, method: str = "minmax", eps: float = 1e-8
+) -> np.ndarray:
     """
-    Nomrmalizes ndarray float to ndarray uint8 in RGB to be compatible with EfficientNetB0.
+    Generic normalization function for spectrograms or tensors.
 
     Args:
-        arr (np.ndarray): Array to be converted.
+        arr (np.ndarray): Input array to normalize.
+        method (str): Normalization method — one of:
+            - "minmax": scales to [0, 1]
+            - "zscore": zero mean, unit variance
+        eps (float): Small constant to avoid division by zero.
 
     Returns:
-        np.ndarray: Normalized uint8 RGB np.ndarray.
+        np.ndarray: Normalized array as float32.
     """
+    arr = arr.astype(np.float32)
 
-    data = np.asarray(arr, dtype=float)
-    # minmax scaling
-    scaled_data = (data - np.min(data)) / (np.max(data) - np.min(data))
-    scaled_data = (scaled_data * 255).astype(np.uint8)
-
-    # Stack 2D data into 3 channels to create RGB
-    rgb_data = np.stack([scaled_data, scaled_data, scaled_data], axis=-1)
-
-    img = Image.fromarray(rgb_data, "RGB")
-    img = img.resize((224, 224), resample=Image.Resampling.BICUBIC)
-
-    return np.asarray(img)
-
-
-def normalize_globally(data: np.ndarray) -> np.ndarray:
-    """
-    Normalize an array to the [0, 1] range using its global minimum and maximum.
-
-    Args:
-        data (np.ndarray): Input array to normalize.
-
-    Returns:
-        np.ndarray: Normalized array with values scaled between 0 and 1.
-                    Returns an array of zeros if input is empty or all values are equal.
-    """
-
-    data = np.asarray(data, dtype=np.float64)
-    if data.size == 0:
-        return np.zeros_like(data)
-
-    mn = np.nanmin(data)
-    mx = np.nanmax(data)
-
-    if mx - mn == 0:
-        return np.zeros_like(data)
-
-    normalized = (data - mn) / (mx - mn)
-    return normalized
-
-
-def resize_to_224(data: np.ndarray, is_global_normalization: bool = False):
-    """
-    Normalize and convert an array to uint8 RGB format suitable for 224x224 input.
-
-    Args:
-        data (np.ndarray): Input array to process.
-        is_global_normalization (bool, optional): Whether to apply global [0,1] normalization
-            before conversion. Defaults to False.
-
-    Returns:
-        np.ndarray: Array normalized (if specified) and converted to uint8 RGB.
-    """
-
-    if is_global_normalization:
-        data = normalize_globally(data)
-
-    return normalize_to_unint8_rgb(data)
-
-
-def get_top_channels(
-    data: np.ndarray,
-    n_components: int = 3,
-    top_k: int = 3,
-    method: Literal["ica", "pca"] = "pca",
-) -> list[int]:
-    """
-    Returns the indices of the top channels contributing to the first n_components
-    ICA or PCA components.
-
-    Args:
-        data (np.ndarray): Input array to process.
-        n_components (int): Number of components to compute.
-        top_k (int): How many top channels to return.
-        method (str): "ica" or "pca"
-
-    Returns:
-        best_channel_indices (list[int]): List of top channel indices.
-    """
-
-    if method == "ica":
-        decomposer = FastICA(n_components=n_components)
-    elif method == "pca":
-        decomposer = PCA(n_components=n_components)
+    if method == "minmax":
+        normed = (arr - arr.min()) / (arr.max() - arr.min() + eps)
+    elif method == "zscore":
+        normed = (arr - arr.mean()) / (arr.std() + eps)
     else:
-        raise ValueError(f"Unknown method: {method}. Use 'ica' or 'pca'.")
+        raise ValueError(f"Unknown normalization method: {method}")
 
-    decomposer.fit(data.T)  # transpose: (n_samples, n_features)
-
-    # Compute absolute contribution of each channel
-    channel_scores = np.abs(decomposer.components_).sum(axis=0)
-
-    # Get top_k channels
-    best_channel_indices = np.argsort(channel_scores)[::-1][:top_k]
-    return best_channel_indices.tolist()
+    return normed.astype(np.float32)
 
 
 def compute_stft_epoch(
     epoch_signal: np.ndarray,
     max_freq: float = 40.0,
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """
     Compute the Short-Time Fourier Transform (STFT) for a 1-D epoch signal.
 
@@ -232,270 +152,249 @@ def compute_stft_epoch(
     Zxx = Zxx_full[mask, :]  # complex (F_trim, T)
     mag = np.abs(Zxx)  # magnitude
     stft_db = 20.0 * np.log10(mag + EPS)  # dB
+    stft_log_mag = np.log1p(mag)
 
     freqs_trim = freqs[mask]
 
-    return stft_db, freqs_trim, times, Zxx
+    return stft_db, freqs_trim, times, Zxx, stft_log_mag
 
 
-def compute_stft_for_segment(
-    data: np.ndarray,
-    interval: EpochInterval,
-    normalize_power: bool,
+def compute_stft_for_epoch(
+    data: np.ndarray, interval: IntervalMeta, normalize_power: bool, epoch_idx: int
 ) -> StftStore:
     """
-    Compute STFT for one signal segment (single channel, single epoch).
+    Compute STFT for one EEG segment that includes multiple channels.
 
     Args:
-        data (np.ndarray): Input array to process.
+        data (np.ndarray): Input array with shape (n_channels, n_samples)
         interval (EpochInterval): Current epoch interval to process.
-        normalize_power (bool): Whether to normalize STFT power to db.
+        normalize_power (bool): Whether to normalize STFT power to dB.
+
+    Returns:
+        StftStore: stores multi-channel STFT results (each key stores per-channel arrays)
     """
     if data.size == 0:
         return StftStore(
             start=interval.start,
             end=interval.end,
             phase=interval.phase,
-            stft_db=np.empty((0, 0)),
-            power=np.empty((0, 0)),
-            Zxx=np.empty((0, 0)),
+            stft_db=np.empty((0, 0, 0)),
+            power=np.empty((0, 0, 0)),
+            Zxx=np.empty((0, 0, 0), dtype=np.complex64),
+            mag=np.empty(0, 0, 0),
             freqs=np.empty(0),
             times=np.empty(0),
         )
 
-    sig = np.squeeze(data)
-    stft_db, freqs, times, Zxx = compute_stft_epoch(epoch_signal=sig)
+    stft_db_list, power_list, Zxx_list, stft_mag_list = [], [], [], []
+    logger.info(
+        f"Number of channels: {data.shape[0]} | "
+        f"Epoch index: {epoch_idx} | "
+        f"Start: {interval.start} | "
+        f"End: {interval.end} | "
+        f"Phase: {interval.phase} | "
+        f"Recording: {interval.file_name}"
+    )
 
-    power = stft_db_to_power(stft_db)
-    if normalize_power and power is not None:
-        power = normalize_power_matrix(power)
+    for ch in range(data.shape[0]):
+        sig = np.squeeze(data[ch])
+        stft_db, freqs, times, Zxx, stft_log_mag = compute_stft_epoch(epoch_signal=sig)
+        power = stft_db_to_power(stft_db)
+
+        if normalize_power and power is not None:
+            power = normalize_power_matrix(power)
+
+        stft_db_list.append(normalize_array(stft_db))
+        power_list.append(power)
+        Zxx_list.append(Zxx)
+        stft_mag_list.append(normalize_array(stft_log_mag))
+
+    # Stack into one 3D array (channels, freq, time)
+    stft_db_all = np.stack(stft_db_list, axis=0)
+    power_all = np.stack(power_list, axis=0)
+    Zxx_all = np.stack(Zxx_list, axis=0)
+    stft_mag_all = np.stack(stft_mag_list, axis=0)
 
     return StftStore(
         start=interval.start,
         end=interval.end,
         phase=interval.phase,
-        stft_db=stft_db,
-        power=power,
-        Zxx=Zxx,
+        stft_db=stft_db_all,
+        power=power_all,
+        Zxx=Zxx_all,
+        mag=stft_mag_all,
         freqs=freqs,
         times=times,
+        seizure_id=interval.seizure_id,
     )
 
 
-def precompute_stfts(
+def precompute_stft(
     recording: BaseRaw,
     patient_stfts_dir: str,
-    segmented_intervals: List[EpochInterval],
+    segmented_epochs: list[IntervalMeta],
     normalize_power: bool = False,
     normalization_method: str = "minmax",
-) -> dict[str, int]:
+):
     """
-    Precomputes Short-Time Fourier Transform (STFT) representations for all labeled epochs
-    and all selected channels in a single patient recording.
-    The STFTs will also be saved in the disk by the use of npz.
-    This is intended to be used by both TF and bispectrum branches.
-    Args:
-        recording (BaseRaw): The continuous EEG recording instance.
-        patient_stft_dir (str): Path where the patient's STFTs will be saved.
-            Results are organized by channel, e.g.:
-                <patient_stft_dir>/<channel_name>/epoch_<start>_<end>.npz
-        segmented_intervals (List[EpochInterval]): List of intervals that define the
-            start, end, and phase of each epoch to be analyzed.
-        normalize_power (bool, optional): Whether to normalize the power matrix.
-            Defaults to False.
-        normalization_method (str, optional): Normalization method to apply if
-            normalize_power is True. Defaults to "minmax".
-
-    Saved NPZ file contents (per epoch, per channel):
-        - start (float): Start time of the epoch (in seconds).
-        - end (float): End time of the epoch (in seconds).
-        - phase (str): Phase label associated with the epoch.
-        - stft_db (ndarray): STFT in decibel scale, shape (F, T).
-        - power (ndarray): Linear power matrix (or empty if disabled), shape (F, T).
-        - Zxx (ndarray): Complex STFT coefficients, shape (F, T).
-        - freqs (ndarray): Frequency bins, shape (F,).
-        - times (ndarray): Time bins, shape (T,).
+    Precompute STFTs for all epochs and save each epoch as an HDF5 file.
+    All channels are saved in a single file per epoch.
     """
+    # TODO: perform undersampling here wherein we match the number of epochs of intericals
+    # with the number of epochs of preictals
 
-    logger.info("Starting STFT precomputation")
-    logger.info(f"Total intervals to process: {len(segmented_intervals)}")
+    # The logic:
+    # 1. loop through the segmented intervals then make 2 lists for preictals and interictals separately
+    # 2. add the epoch intervals accordingly to their phase e.g. interictal -> interictals_list
+    # 3. apply random.sample to interictals list wherein N is the number of preictal epochs
+
+    phase_counts = {}
+    for epoch in segmented_epochs:
+        phase_counts[epoch.phase] = phase_counts.get(epoch.phase, 0) + 1
+    logger.info(f"Epochs by phase: {phase_counts}")
+
     logger.info(f"Normalize power: {normalize_power}")
 
-    if normalize_power:
-        logger.info(f"Normalization method: {normalization_method}")
-
-    channel_names = PreprocessingConfig.selected_channels
     sfreq = float(recording.info["sfreq"])
+    os.makedirs(patient_stfts_dir, exist_ok=True)
 
-    logger.info(f"Selected channels: {len(channel_names)}")
-    logger.info(f"Sampling frequency: {sfreq} Hz")
+    h5_lock = Lock()
 
-    ch_index_map = {name: recording.ch_names.index(name) for name in channel_names}
+    tasks = list(enumerate(segmented_epochs))
 
-    # Count intervals by phase for summary
-    phase_counts = {}
-    for epoch in segmented_intervals:
-        phase_counts[epoch.phase] = phase_counts.get(epoch.phase, 0) + 1
-    logger.info(f"Intervals by phase: {phase_counts}")
+    def _save_stft_epoch(task: tuple[int, IntervalMeta]) -> bool:
+        idx, epoch = task
+        start_sample = int(epoch.start * sfreq)
+        end_sample = int(epoch.end * sfreq)
 
-    def _save_channel_epoch_stft(object: tuple[str, EpochInterval]) -> bool:
-        ch, epoch = object
-        start_sec, end_sec, phase = epoch.start, epoch.end, epoch.phase
-        start_sample, end_sample = int(start_sec * sfreq), int(end_sec * sfreq)
+        stem = os.path.splitext(os.path.basename(str(epoch.file_name)))[0]
+        base_name = f"{epoch.phase}_{stem}_{int(epoch.start):06d}_{int(epoch.end):06d}"
+        out_name = f"{base_name}.h5"
+        filename = os.path.join(patient_stfts_dir, out_name)
 
-        logger.debug(
-            f"Epoch: "
-            f"{phase} [{start_sec}-{end_sec}s] samples [{start_sample}-{end_sample}]"
+        # Quick check to skip existing files
+        if os.path.exists(filename):
+            return False
+
+        # Extract EEG data for selected channels
+        data = recording.get_data(
+            picks=PreprocessingConfig.selected_channels,
+            start=start_sample,
+            stop=end_sample,
+        ).astype(np.float32)
+
+        # Compute STFT for this epoch
+        computed_stft = compute_stft_for_epoch(
+            np.asarray(data), epoch, normalize_power, idx
         )
 
-        idx_ch = ch_index_map[ch]
+        try:
+            # Thread-safe write
+            with h5_lock:
+                with h5py.File(filename, "w") as f:
+                    f.create_dataset("Zxx", data=computed_stft.Zxx, compression="gzip")
+                    f.create_dataset(
+                        "stft_db", data=computed_stft.stft_db, compression="gzip"
+                    )
+                    f.create_dataset("mag", data=computed_stft.mag, compression="gzip")
+                    f.create_dataset(
+                        "freqs", data=computed_stft.freqs, compression="gzip"
+                    )
+                    f.create_dataset(
+                        "times", data=computed_stft.times, compression="gzip"
+                    )
+                    if getattr(computed_stft, "power", None) is not None:
+                        f.create_dataset(
+                            "power", data=computed_stft.power, compression="gzip"
+                        )
 
-        # Save inside <patient_dir>/<channel>/
-        channel_dir = os.path.join(patient_stfts_dir, ch)
-        os.makedirs(channel_dir, exist_ok=True)
-        filename = os.path.join(channel_dir, f"epoch_{epoch.start}_{epoch.end}.npz")
-
-        if not os.path.exists(filename):
-            data = recording.get_data(
-                picks=[idx_ch], start=start_sample, stop=end_sample
-            ).astype(np.float32)
-            data_2d = np.asarray(data)
-
-            computed_stft = compute_stft_for_segment(
-                data_2d,
-                epoch,
-                normalize_power,
-            )
-
-            try:
-                np.savez_compressed(filename, **computed_stft.__dict__)
-            except Exception as e:
-                logger.error(f"Failed to save {filename}: {e}")
+                    # Save metadata as attributes
+                    f.attrs["phase"] = computed_stft.phase
+                    f.attrs["start"] = computed_stft.start
+                    f.attrs["end"] = computed_stft.end
+                    f.attrs["seizure_id"] = computed_stft.seizure_id
+                    f.attrs["file_name"] = base_name
 
             return True
-        return False
+        except Exception as e:
+            logger.error(f"Failed to save {filename}: {e}")
+            return False
 
-    tasks: list[tuple[str, EpochInterval]] = [
-        (ch, epoch) for epoch in segmented_intervals for ch in channel_names
-    ]
-
-    start = time.perf_counter()
+    # Parallel execution for STFT computation
     with ThreadPoolExecutor(max_workers=os.cpu_count() or 1) as pool:
         results = list(
             tqdm(
-                pool.map(_save_channel_epoch_stft, tasks),
+                pool.map(_save_stft_epoch, tasks),
                 total=len(tasks),
                 desc="Computing STFTs",
             )
         )
 
-    elapsed = time.perf_counter() - start
-
-    total_tasks = len(tasks)
-    avg_speed = total_tasks / elapsed
-
-    logger.debug(f"Average speed: {avg_speed:.2f} it/s")
     logger.info("STFT precomputation completed successfully!")
-    logger.info(
-        f"Processed {len(results)} STFT epochs across {len(channel_names)} channels"
-    )
+    logger.info(f"Processed {len(results)} STFT epochs")
     logger.info(f"Total STFT files created: {sum(results)}")
     logger.info(f"Results saved in: {patient_stfts_dir}")
 
     return phase_counts
 
 
-def build_epoch_mosaic(
-    epoch_idx: int,
-    mode: Literal["tf_band", "tf_detailed", "bispectrum"],
-    band_maps: Optional[dict[str, list[BandTimeStore]]] = None,
-    stfts_by_channel: dict[str, list[StftStore]] = {},
-    per_tile_normalization: bool = True,
-    grid: tuple[int, int] = (4, 4),
-    bispectrum_arr_list: Optional[list[np.ndarray]] = None,
-) -> tuple[np.ndarray, str]:
+def normalize_to_imagenet(img: np.ndarray) -> np.ndarray:
     """
-    Build a 2D mosaic representation of an EEG epoch from multiple channels.
-
-    Args:
-        epoch_idx (int): Index of the epoch to process.
-        band_maps (dict[str, list[BandTimeStore]], optional): Precomputed band-level data per channel.
-        stfts_by_channel (dict[str, list[StftStore]]): STFT results for each channel.
-        mode (str): Mode of representation to build:
-            "tf_band", "tf_detailed", or "bispectrum".
-        per_tile_normalization (bool, optional): Whether to apply min-max normalization to each tile. Defaults to True.
-        grid (tuple[int, int], optional): Grid layout (rows, cols) for the mosaic. Defaults to (4, 4).
-        bispectrum_arr_list (list[np.ndarray], optional): Optional bispectrum arrays to use instead of STFT/power.
-
-    Returns:
-        tuple[np.ndarray, str]:
-            - Mosaic array of shape (H, W) after concatenating all tiles.
-            - The type of representation used ("time_frequency_band", "time_frequency_detailed", or "bispectrum").
+    Normalize an image to ImageNet statistics in channel-first format (C, H, W).
+    Converts grayscale to 3-channel if needed.
     """
+    img = np.asarray(img, dtype=np.float32)
 
-    rows, cols = grid
-    logger.info(
-        f"Building epoch mosaic - epoch_idx: {epoch_idx}, mode: '{mode}', "
-        f"per_tile_normalization: {per_tile_normalization}, grid: {rows}x{cols}"
-    )
+    # Ensure channel-first (C, H, W)
+    if img.ndim == 2:  # (H, W)
+        img = np.stack([img] * 3, axis=0)
+    elif img.ndim == 3 and img.shape[0] not in (1, 3):  # (H, W, C) -> (C, H, W)
+        img = np.transpose(img, (2, 0, 1))
+    elif img.ndim == 3 and img.shape[0] == 1:  # (1, H, W)
+        img = np.repeat(img, 3, axis=0)
 
-    tiles: list[np.ndarray] = []
-    channel_names = list(stfts_by_channel.keys())
-    logger.debug(f"Processing {len(channel_names)} channels: {channel_names}")
+    # Scale to [0, 1]
+    img = img / 255.0
 
-    for ch_idx, (ch_name, epochs) in enumerate(stfts_by_channel.items()):
-        if bispectrum_arr_list is not None:
-            tile = bispectrum_arr_list[ch_idx]
+    # ImageNet normalization
+    mean = np.array([0.485, 0.456, 0.406], dtype=np.float32)[:, None, None]  # (3,1,1)
+    std = np.array([0.229, 0.224, 0.225], dtype=np.float32)[:, None, None]  # (3,1,1)
+    return (img - mean) / std
+
+
+def create_efficientnet_img(data: np.ndarray, target_size=(224, 224)) -> np.ndarray:
+    """
+    Resize a 2D or 3D spectrogram to target size (224x224) while keeping float values in 0–1.
+    Returns channel-first (C, H, W) array for PyTorch.
+
+    Accepts:
+        - (H, W)
+        - (H, W, 3)
+        - (3, H, W)
+    """
+    logger.info(f"Data shape (before): {data.shape}")
+    data = np.asarray(data, dtype=float)
+
+    scaled_data = (data - np.min(data)) / (np.max(data) - np.min(data) + 1e-8)
+    scaled_data = (scaled_data * 255).astype(np.uint8)
+
+    if scaled_data.ndim == 2:
+        rgb_data = np.stack([scaled_data] * 3, axis=-1)  # (H, W, 3)
+    elif scaled_data.ndim == 3:
+        if scaled_data.shape[0] == 3:
+            rgb_data = np.transpose(scaled_data, (1, 2, 0))
+        elif scaled_data.shape[2] == 3:
+            rgb_data = scaled_data
         else:
-            if mode == "tf_band":
-                if band_maps is None:
-                    raise ValueError(
-                        "band_maps is required when type == 'time_frequency_band'"
-                    )
-                tile = band_maps[ch_name][epoch_idx].band_time
-            else:
-                tile = epochs[epoch_idx].power
+            raise ValueError(f"Expected 3 channels, got shape {scaled_data.shape}")
+    else:
+        raise ValueError(f"Unsupported data shape: {scaled_data.shape}")
 
-        logger.debug(
-            f"Channel '{ch_name}' ({ch_idx + 1}/{len(channel_names)}): "
-            f"extracted {mode} data, shape: {tile.shape}"
-        )
+    img = Image.fromarray(rgb_data, "RGB")
+    img = img.resize(target_size, resample=Image.Resampling.BICUBIC)
 
-        if per_tile_normalization:
-            normalized_tile = minmax_scale(tile.flatten()).reshape(tile.shape)
-            logger.debug(f"Channel '{ch_name}': applied minmax normalization")
-        else:
-            normalized_tile = tile
+    img_arr = np.array(img).astype(np.float32)
+    img_arr = np.transpose(img_arr, (2, 0, 1))  # (H, W, C) -> (C, H, W)
 
-        tiles.append(np.asarray(normalized_tile, dtype=np.float64))
-
-    # Calculate grid requirements
-    n_tiles = len(tiles)
-    required_tiles = rows * cols
-    logger.debug(f"Grid requires {required_tiles} tiles, have {n_tiles} channels")
-
-    # Pad if needed
-    if n_tiles < required_tiles:
-        padding_needed = required_tiles - n_tiles
-        logger.debug(f"Padding with {padding_needed} zero tiles")
-        for _ in range(padding_needed):
-            tiles.append(np.zeros_like(tiles[0]))
-
-    # Build grid
-    logger.debug(f"Building {rows}x{cols} grid from {len(tiles)} tiles")
-    grid_rows: list[np.ndarray] = []
-    for r in range(rows):
-        row_tiles = tiles[r * cols : (r + 1) * cols]
-        grid_row = np.concatenate(row_tiles, axis=1)
-        grid_rows.append(grid_row)
-        logger.debug(
-            f"Row {r}: concatenated {len(row_tiles)} tiles, shape: {grid_row.shape}"
-        )
-
-    mosaic = np.concatenate(grid_rows, axis=0)
-    logger.info(
-        f"Mosaic construction complete - final shape: {mosaic.shape}, "
-        f"used {n_tiles} channels in {rows}x{cols} grid"
-    )
-
-    return mosaic, mode
+    logger.info(f"Data shape (after): {img_arr.shape}")
+    return img_arr

--- a/src/preprocessing/run_time_frequency_pipeline.py
+++ b/src/preprocessing/run_time_frequency_pipeline.py
@@ -1,11 +1,12 @@
 """
-Time-Frquency Pipeline Module
+Time-Frequency Pipeline Module
 
-This module is the main module for piecing togother all the functions that are needed to process
+This module is the main module for piecing together all the functions that are needed to process
 the time-frequency features and extract them into mosaic tensor.
 """
 
 import os
+from typing import cast
 
 import numpy as np
 from tqdm import tqdm
@@ -14,11 +15,12 @@ from tqdm.contrib.logging import logging_redirect_tqdm
 from src.config import DataConfig
 from src.datatypes import StftStore
 from src.logger import get_all_active_loggers, setup_logger
-from src.utils import export_to_csv, is_precomputed_data_exists
+from src.preprocessing.data_transformation import (
+    create_efficientnet_img,
+)
+from src.utils import is_precomputed_data_exists
 
-from .data_transformation import build_epoch_mosaic, normalize_globally, resize_to_224
 from .loaders import load_precomputed_stfts
-from .time_frequency_branch import create_band_groupings_per_channel
 
 logger = setup_logger(name="time_frequency_pipeline")
 active_loggers = get_all_active_loggers()
@@ -28,8 +30,7 @@ def main():
     """
     Data Preprocessing
     - Data transformation for time-frequency branch
-        - Band groupings per channel
-        - Mosaic for STFT matrix
+        - Reduce channels: R=mean, G=max, B=std
         - Global normalization
         - Resize to 224x224x3
         - Save to npz
@@ -57,63 +58,49 @@ def main():
                 )
                 continue
 
-            # 1. Load precomputed stfts
-            stfts_by_channel: dict[str, list[StftStore]] = load_precomputed_stfts(
-                patient_stfts_dir
-            )
+            # 1. Load precomputed stfts (all channels)
+            loaded_stft_epochs = load_precomputed_stfts(patient_stfts_dir)
 
-            # 2. Band groupings per channel
-            band_maps = create_band_groupings_per_channel(stfts_by_channel)
-
-            # Get epochs from first channel
-            first_channel_epochs = next(iter(stfts_by_channel.values()))
-            n_epochs = len(first_channel_epochs)
-
-            # 3. Iterate over epochs and build mosaics
-            processed_files = 0
-            for epoch_idx in tqdm(
-                range(n_epochs),
-                desc=f"Processing epochs for patient {patient_id}",
-                leave=False,
+            # 3. Process each window
+            for idx, stft_epoch in enumerate(
+                tqdm(loaded_stft_epochs, desc="Processing epochs", leave=False)
             ):
-                epoch_meta: StftStore = first_channel_epochs[epoch_idx]
+                stft_epoch = cast(StftStore, stft_epoch)
 
-                mosaic, mode = build_epoch_mosaic(
-                    epoch_idx=epoch_idx,
-                    mode="tf_band",
-                    band_maps=band_maps,
-                    stfts_by_channel=stfts_by_channel,
+                # stft_band_averaged = band_average_stft(stft)
+                stft_mag = stft_epoch.mag
+                stft_mag_avg = np.mean(stft_mag, axis=0)
+
+                # 6. Resize to 224x224x3
+                spectrogram_mosaic = create_efficientnet_img(stft_mag_avg)
+                logger.info(
+                    f"Spectrogram shape: {spectrogram_mosaic.shape} | "
+                    f"Epoch index: {idx} | "
+                    f"Start: {stft_epoch.start} | "
+                    f"End: {stft_epoch.end} | "
+                    f"Phase: {stft_epoch.phase}"
                 )
 
-                # 4. Global normalization
-                normalized = normalize_globally(mosaic)
-
-                # 5. Resize to 224x224x3
-                resized = resize_to_224(normalized)
-
-                # 6. Save to npz
-                filename = os.path.join(
-                    patient_time_frequency_dir,
-                    f"{epoch_meta.phase}_{mode}_{epoch_meta.start}_{epoch_meta.end}.npz",
-                )
+                # 7. Save to npz
+                out_name = f"{stft_epoch.file_name}_tf"
+                filename = os.path.join(patient_time_frequency_dir, f"{out_name}.npz")
 
                 if not os.path.exists(filename):
                     np.savez_compressed(
                         filename,
-                        tensor=resized,
-                        start=epoch_meta.start,
-                        end=epoch_meta.end,
-                        phase=epoch_meta.phase,
+                        tensor=spectrogram_mosaic,
+                        start=stft_epoch.start,
+                        end=stft_epoch.end,
+                        phase=stft_epoch.phase,
+                        freqs=stft_epoch.freqs,
+                        seizure_id=stft_epoch.seizure_id,
+                        n_channels=stft_epoch.stft_db.shape[0],
+                        file_name=out_name,
                     )
-                    processed_files += 1
 
-            precomputed_tf_summary = {
-                "patient_id": patient_id,
-                "mosaics": processed_files,
-            }
-
-            logger.info(f"Finished building mosaics for patient {patient_id}")
-            logger.info(f"Total mosaics files created: {processed_files}")
+            logger.info(
+                f"Finished building time-frequency mosaics for patient {patient_id}"
+            )
             logger.info(f"Results saved in: {patient_time_frequency_dir}")
 
             os.makedirs(DataConfig.runs_dir, exist_ok=True)
@@ -122,12 +109,6 @@ def main():
                 DataConfig.runs_dir, "precomputed_tf.csv"
             )
             fieldnames = ["patient_id", "mosaics"]
-            export_to_csv(
-                path=precomputed_tf_summary_path,
-                fieldnames=fieldnames,
-                data=[precomputed_tf_summary],
-                mode="a",
-            )
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -503,6 +503,62 @@ wheels = [
 ]
 
 [[package]]
+name = "h5py"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/6a/0d79de0b025aa85dc8864de8e97659c94cf3d23148394a954dc5ca52f8c8/h5py-3.15.1.tar.gz", hash = "sha256:c86e3ed45c4473564de55aa83b6fc9e5ead86578773dfbd93047380042e26b69", size = 426236, upload-time = "2025-10-16T10:35:27.404Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b3/40207e0192415cbff7ea1d37b9f24b33f6d38a5a2f5d18a678de78f967ae/h5py-3.15.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c8440fd8bee9500c235ecb7aa1917a0389a2adb80c209fa1cc485bd70e0d94a5", size = 3376511, upload-time = "2025-10-16T10:34:38.596Z" },
+    { url = "https://files.pythonhosted.org/packages/31/96/ba99a003c763998035b0de4c299598125df5fc6c9ccf834f152ddd60e0fb/h5py-3.15.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ab2219dbc6fcdb6932f76b548e2b16f34a1f52b7666e998157a4dfc02e2c4123", size = 2826143, upload-time = "2025-10-16T10:34:41.342Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c2/fc6375d07ea3962df7afad7d863fe4bde18bb88530678c20d4c90c18de1d/h5py-3.15.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8cb02c3a96255149ed3ac811eeea25b655d959c6dd5ce702c9a95ff11859eb5", size = 4908316, upload-time = "2025-10-16T10:34:44.619Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/69/4402ea66272dacc10b298cca18ed73e1c0791ff2ae9ed218d3859f9698ac/h5py-3.15.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:121b2b7a4c1915d63737483b7bff14ef253020f617c2fb2811f67a4bed9ac5e8", size = 5103710, upload-time = "2025-10-16T10:34:48.639Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/f6/11f1e2432d57d71322c02a97a5567829a75f223a8c821764a0e71a65cde8/h5py-3.15.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:59b0d63b318bf3cc06687def2b45afd75926bbc006f7b8cd2b1a231299fc8599", size = 4556042, upload-time = "2025-10-16T10:34:51.841Z" },
+    { url = "https://files.pythonhosted.org/packages/18/88/3eda3ef16bfe7a7dbc3d8d6836bbaa7986feb5ff091395e140dc13927bcc/h5py-3.15.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e02fe77a03f652500d8bff288cbf3675f742fc0411f5a628fa37116507dc7cc0", size = 5030639, upload-time = "2025-10-16T10:34:55.257Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/ea/fbb258a98863f99befb10ed727152b4ae659f322e1d9c0576f8a62754e81/h5py-3.15.1-cp313-cp313-win_amd64.whl", hash = "sha256:dea78b092fd80a083563ed79a3171258d4a4d307492e7cf8b2313d464c82ba52", size = 2864363, upload-time = "2025-10-16T10:34:58.099Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/c9/35021cc9cd2b2915a7da3026e3d77a05bed1144a414ff840953b33937fb9/h5py-3.15.1-cp313-cp313-win_arm64.whl", hash = "sha256:c256254a8a81e2bddc0d376e23e2a6d2dc8a1e8a2261835ed8c1281a0744cd97", size = 2449570, upload-time = "2025-10-16T10:35:00.473Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2c/926eba1514e4d2e47d0e9eb16c784e717d8b066398ccfca9b283917b1bfb/h5py-3.15.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5f4fb0567eb8517c3ecd6b3c02c4f4e9da220c8932604960fd04e24ee1254763", size = 3380368, upload-time = "2025-10-16T10:35:03.117Z" },
+    { url = "https://files.pythonhosted.org/packages/65/4b/d715ed454d3baa5f6ae1d30b7eca4c7a1c1084f6a2edead9e801a1541d62/h5py-3.15.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:954e480433e82d3872503104f9b285d369048c3a788b2b1a00e53d1c47c98dd2", size = 2833793, upload-time = "2025-10-16T10:35:05.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d4/ef386c28e4579314610a8bffebbee3b69295b0237bc967340b7c653c6c10/h5py-3.15.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fd125c131889ebbef0849f4a0e29cf363b48aba42f228d08b4079913b576bb3a", size = 4903199, upload-time = "2025-10-16T10:35:08.972Z" },
+    { url = "https://files.pythonhosted.org/packages/33/5d/65c619e195e0b5e54ea5a95c1bb600c8ff8715e0d09676e4cce56d89f492/h5py-3.15.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:28a20e1a4082a479b3d7db2169f3a5034af010b90842e75ebbf2e9e49eb4183e", size = 5097224, upload-time = "2025-10-16T10:35:12.808Z" },
+    { url = "https://files.pythonhosted.org/packages/30/30/5273218400bf2da01609e1292f562c94b461fcb73c7a9e27fdadd43abc0a/h5py-3.15.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fa8df5267f545b4946df8ca0d93d23382191018e4cda2deda4c2cedf9a010e13", size = 4551207, upload-time = "2025-10-16T10:35:16.24Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/39/a7ef948ddf4d1c556b0b2b9559534777bccc318543b3f5a1efdf6b556c9c/h5py-3.15.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99d374a21f7321a4c6ab327c4ab23bd925ad69821aeb53a1e75dd809d19f67fa", size = 5025426, upload-time = "2025-10-16T10:35:19.831Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/d8/7368679b8df6925b8415f9dcc9ab1dab01ddc384d2b2c24aac9191bd9ceb/h5py-3.15.1-cp314-cp314-win_amd64.whl", hash = "sha256:9c73d1d7cdb97d5b17ae385153472ce118bed607e43be11e9a9deefaa54e0734", size = 2865704, upload-time = "2025-10-16T10:35:22.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b7/4a806f85d62c20157e62e58e03b27513dc9c55499768530acc4f4c5ce4be/h5py-3.15.1-cp314-cp314-win_arm64.whl", hash = "sha256:a6d8c5a05a76aca9a494b4c53ce8a9c29023b7f64f625c6ce1841e92a362ccdf", size = 2465544, upload-time = "2025-10-16T10:35:25.695Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.1.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/31/feeddfce1748c4a233ec1aa5b7396161c07ae1aa9b7bdbc9a72c3c7dd768/hf_xet-1.1.10.tar.gz", hash = "sha256:408aef343800a2102374a883f283ff29068055c111f003ff840733d3b715bb97", size = 487910, upload-time = "2025-09-12T20:10:27.12Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/a2/343e6d05de96908366bdc0081f2d8607d61200be2ac802769c4284cc65bd/hf_xet-1.1.10-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:686083aca1a6669bc85c21c0563551cbcdaa5cf7876a91f3d074a030b577231d", size = 2761466, upload-time = "2025-09-12T20:10:22.836Z" },
+    { url = "https://files.pythonhosted.org/packages/31/f9/6215f948ac8f17566ee27af6430ea72045e0418ce757260248b483f4183b/hf_xet-1.1.10-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:71081925383b66b24eedff3013f8e6bbd41215c3338be4b94ba75fd75b21513b", size = 2623807, upload-time = "2025-09-12T20:10:21.118Z" },
+    { url = "https://files.pythonhosted.org/packages/15/07/86397573efefff941e100367bbda0b21496ffcdb34db7ab51912994c32a2/hf_xet-1.1.10-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b6bceb6361c80c1cc42b5a7b4e3efd90e64630bcf11224dcac50ef30a47e435", size = 3186960, upload-time = "2025-09-12T20:10:19.336Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a7/0b2e242b918cc30e1f91980f3c4b026ff2eedaf1e2ad96933bca164b2869/hf_xet-1.1.10-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eae7c1fc8a664e54753ffc235e11427ca61f4b0477d757cc4eb9ae374b69f09c", size = 3087167, upload-time = "2025-09-12T20:10:17.255Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/25/3e32ab61cc7145b11eee9d745988e2f0f4fafda81b25980eebf97d8cff15/hf_xet-1.1.10-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0a0005fd08f002180f7a12d4e13b22be277725bc23ed0529f8add5c7a6309c06", size = 3248612, upload-time = "2025-09-12T20:10:24.093Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3d/ab7109e607ed321afaa690f557a9ada6d6d164ec852fd6bf9979665dc3d6/hf_xet-1.1.10-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f900481cf6e362a6c549c61ff77468bd59d6dd082f3170a36acfef2eb6a6793f", size = 3353360, upload-time = "2025-09-12T20:10:25.563Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/0e/471f0a21db36e71a2f1752767ad77e92d8cde24e974e03d662931b1305ec/hf_xet-1.1.10-cp37-abi3-win_amd64.whl", hash = "sha256:5f54b19cc347c13235ae7ee98b330c26dd65ef1df47e5316ffb1e87713ca7045", size = 2804691, upload-time = "2025-09-12T20:10:28.433Z" },
+]
+
+[[package]]
+name = "higher-spectrum"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/cf/cdfbb08e5587890c10d80c03f02567329a0e76a75d7a6490719c03462bea/higher_spectrum-0.3.0.tar.gz", hash = "sha256:fa433a486ac6df5d2d391c041dae015bb0a4ba1783cb8f777db23062fa411678", size = 782211, upload-time = "2025-06-07T10:17:23.838Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/0a/d88dad07fa3d66be3f8deef2b228bee84ce852e2009cbfd3969f02b4eb65/higher_spectrum-0.3.0-py3-none-any.whl", hash = "sha256:0cb212e98a8587a90d5736f0bc2561aef7c9cf3f48824e1bf85410f2b8adaeeb", size = 41970, upload-time = "2025-06-07T10:17:11.473Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -528,6 +584,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "0.35.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/7e/a0a97de7c73671863ca6b3f61fa12518caf35db37825e43d63a70956738c/huggingface_hub-0.35.3.tar.gz", hash = "sha256:350932eaa5cc6a4747efae85126ee220e4ef1b54e29d31c3b45c5612ddf0b32a", size = 461798, upload-time = "2025-09-29T14:29:58.625Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/a0/651f93d154cb72323358bf2bbae3e642bdb5d2f1bfc874d096f7cb159fa0/huggingface_hub-0.35.3-py3-none-any.whl", hash = "sha256:0e3a01829c19d86d03793e4577816fe3bdfc1602ac62c7fb220d593d351224ba", size = 564262, upload-time = "2025-09-29T14:29:55.813Z" },
 ]
 
 [[package]]
@@ -2021,6 +2096,28 @@ wheels = [
 ]
 
 [[package]]
+name = "safetensors"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/cc/738f3011628920e027a11754d9cae9abec1aed00f7ae860abbf843755233/safetensors-0.6.2.tar.gz", hash = "sha256:43ff2aa0e6fa2dc3ea5524ac7ad93a9839256b8703761e76e2d0b2a3fa4f15d9", size = 197968, upload-time = "2025-08-08T13:13:58.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/b1/3f5fd73c039fc87dba3ff8b5d528bfc5a32b597fea8e7a6a4800343a17c7/safetensors-0.6.2-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9c85ede8ec58f120bad982ec47746981e210492a6db876882aa021446af8ffba", size = 454797, upload-time = "2025-08-08T13:13:52.066Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c9/bb114c158540ee17907ec470d01980957fdaf87b4aa07914c24eba87b9c6/safetensors-0.6.2-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:d6675cf4b39c98dbd7d940598028f3742e0375a6b4d4277e76beb0c35f4b843b", size = 432206, upload-time = "2025-08-08T13:13:50.931Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8e/f70c34e47df3110e8e0bb268d90db8d4be8958a54ab0336c9be4fe86dac8/safetensors-0.6.2-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d2d2b3ce1e2509c68932ca03ab8f20570920cd9754b05063d4368ee52833ecd", size = 473261, upload-time = "2025-08-08T13:13:41.259Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/f5/be9c6a7c7ef773e1996dc214e73485286df1836dbd063e8085ee1976f9cb/safetensors-0.6.2-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:93de35a18f46b0f5a6a1f9e26d91b442094f2df02e9fd7acf224cfec4238821a", size = 485117, upload-time = "2025-08-08T13:13:43.506Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/55/23f2d0a2c96ed8665bf17a30ab4ce5270413f4d74b6d87dd663258b9af31/safetensors-0.6.2-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:89a89b505f335640f9120fac65ddeb83e40f1fd081cb8ed88b505bdccec8d0a1", size = 616154, upload-time = "2025-08-08T13:13:45.096Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c6/affb0bd9ce02aa46e7acddbe087912a04d953d7a4d74b708c91b5806ef3f/safetensors-0.6.2-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fc4d0d0b937e04bdf2ae6f70cd3ad51328635fe0e6214aa1fc811f3b576b3bda", size = 520713, upload-time = "2025-08-08T13:13:46.25Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/5d/5a514d7b88e310c8b146e2404e0dc161282e78634d9358975fd56dfd14be/safetensors-0.6.2-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8045db2c872db8f4cbe3faa0495932d89c38c899c603f21e9b6486951a5ecb8f", size = 485835, upload-time = "2025-08-08T13:13:49.373Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/7b/4fc3b2ba62c352b2071bea9cfbad330fadda70579f617506ae1a2f129cab/safetensors-0.6.2-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:81e67e8bab9878bb568cffbc5f5e655adb38d2418351dc0859ccac158f753e19", size = 521503, upload-time = "2025-08-08T13:13:47.651Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/50/0057e11fe1f3cead9254315a6c106a16dd4b1a19cd247f7cc6414f6b7866/safetensors-0.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b0e4d029ab0a0e0e4fdf142b194514695b1d7d3735503ba700cf36d0fc7136ce", size = 652256, upload-time = "2025-08-08T13:13:53.167Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/29/473f789e4ac242593ac1656fbece6e1ecd860bb289e635e963667807afe3/safetensors-0.6.2-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:fa48268185c52bfe8771e46325a1e21d317207bcabcb72e65c6e28e9ffeb29c7", size = 747281, upload-time = "2025-08-08T13:13:54.656Z" },
+    { url = "https://files.pythonhosted.org/packages/68/52/f7324aad7f2df99e05525c84d352dc217e0fa637a4f603e9f2eedfbe2c67/safetensors-0.6.2-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:d83c20c12c2d2f465997c51b7ecb00e407e5f94d7dec3ea0cc11d86f60d3fde5", size = 692286, upload-time = "2025-08-08T13:13:55.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/cad1d9762868c7c5dc70c8620074df28ebb1a8e4c17d4c0cb031889c457e/safetensors-0.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d944cea65fad0ead848b6ec2c37cc0b197194bec228f8020054742190e9312ac", size = 655957, upload-time = "2025-08-08T13:13:57.029Z" },
+    { url = "https://files.pythonhosted.org/packages/59/a7/e2158e17bbe57d104f0abbd95dff60dda916cf277c9f9663b4bf9bad8b6e/safetensors-0.6.2-cp38-abi3-win32.whl", hash = "sha256:cab75ca7c064d3911411461151cb69380c9225798a20e712b102edda2542ddb1", size = 308926, upload-time = "2025-08-08T13:14:01.095Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c3/c0be1135726618dc1e28d181b8c442403d8dbb9e273fd791de2d4384bcdd/safetensors-0.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:c7b214870df923cbc1593c3faee16bec59ea462758699bd3fee399d00aac072c", size = 320192, upload-time = "2025-08-08T13:13:59.467Z" },
+]
+
+[[package]]
 name = "scikit-learn"
 version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2256,6 +2353,8 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },
+    { name = "h5py" },
+    { name = "higher-spectrum" },
     { name = "jupyterlab" },
     { name = "jupyterlab-vim" },
     { name = "kaggle" },
@@ -2270,6 +2369,7 @@ dependencies = [
     { name = "scipy" },
     { name = "seaborn" },
     { name = "tensorboard" },
+    { name = "timm" },
     { name = "toml" },
     { name = "torch" },
     { name = "torchvision" },
@@ -2279,6 +2379,8 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.118.0" },
+    { name = "h5py", specifier = ">=3.15.1" },
+    { name = "higher-spectrum", specifier = ">=0.3.0" },
     { name = "jupyterlab", specifier = ">=4.4.9" },
     { name = "jupyterlab-vim", specifier = ">=4.1.4" },
     { name = "kaggle", specifier = ">=1.7.4.5" },
@@ -2293,6 +2395,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.16.2" },
     { name = "seaborn", specifier = ">=0.13.2" },
     { name = "tensorboard", specifier = ">=2.20.0" },
+    { name = "timm", specifier = ">=1.0.20" },
     { name = "toml", specifier = ">=0.10.2" },
     { name = "torch", specifier = ">=2.8.0" },
     { name = "torchvision", specifier = ">=0.23.0" },
@@ -2306,6 +2409,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
+name = "timm"
+version = "1.0.20"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch" },
+    { name = "torchvision" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/ba/6f5d96622a4a9fc315da53f58b3ca224c66015efe40aa191df0d523ede7c/timm-1.0.20.tar.gz", hash = "sha256:7468d32a410c359181c1ef961f49c7e213286e0c342bfb898b99534a4221fc54", size = 2360052, upload-time = "2025-09-21T17:26:35.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/74/5573615570bf010f788e977ac57c4b49db0aaf6d634134f6a9212d8dcdfd/timm-1.0.20-py3-none-any.whl", hash = "sha256:f6e62f780358476691996c47aa49de87b95cc507edf923c3042f74a07e45b7fe", size = 2504047, upload-time = "2025-09-21T17:26:33.487Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Pre-precessing Changes

- The `data_cleaning` module fa5843e87daf4dca886f981ea6584d2f14874049 now finally gets the correct preictals, it also now has under sampling of interictals by default wherein it would first match the interictal files with the number of accepted preictals then later balance the number of epochs.
- Computation of stfts are revamped wherein instead of saving the stfts per channel as a folder, it is now 1 file per epoch containing all computed stft per channel f8ee72f2bf009ddcf8921c7a7d0a94d4df99bc9b
- Time-frequency and bispectrum features that are saved as image arrays are no longer in the form of mosaics, instead each averaging across all channels are done.

# Model Changes 

- Loading of data is now revamped wherein it would first load the tensor then normalize time-frequency features to imagenet while bispectrum only through non-imagenet normalization
- These features are also now stored though the Dataset class of pytorch which allows to create custom dataset classes that can be used for easier handling of the data
- LOOCV now is completely different from before, it is no longer per sample (will elaborate more on this in the future)